### PR TITLE
Bump brakeman from 8.0.4 to 8.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
## Summary
- Brakeman's own scan_ruby CI check fails when the installed gem version isn't the latest release on rubygems.org
- Gemfile.lock had brakeman pinned to 8.0.4 (latest is 8.0.5), which was blocking scan_ruby on every open Dependabot PR
- Bumps to 8.0.5 to unblock CI across the board

## Test plan
- [x] `bin/brakeman --no-pager` runs clean locally with no version warning